### PR TITLE
Create regex only once

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,10 @@
 import find from './find';
 
+const CONFIG_REGEX = /^[^/]+\/config\/environment$/;
+
 export function findConfigName(entries) {
   return find.call(Object.keys(entries), (entry) => {
-    return entry.match(/^[^/]+\/config\/environment$/);
+    return CONFIG_REGEX.test(entry);
   });
 }
 


### PR DESCRIPTION
Create the regular expression used for matching the config file's module name only once instead of creating it each time the filter callback is invoked.