### PR TITLE
Break early after finding config module name

### DIFF
--- a/addon/find.js
+++ b/addon/find.js
@@ -1,0 +1,10 @@
+// Polyfill only as much as we need (don't need thisArg)
+export function Array_find(callback) {
+  for (var i = 0, entry = this[i]; i < this.length; entry = this[++i]) {
+    if (callback(entry, i, this)) {
+      return entry;
+    }
+  }
+}
+
+export default (Array.prototype.find || Array_find);

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,7 +1,9 @@
+import find from './find';
+
 export function findConfigName(entries) {
-  return Object.keys(entries).filter((entry) => {
+  return find.call(Object.keys(entries), (entry) => {
     return entry.match(/^[^/]+\/config\/environment$/);
-  })[0];
+  });
 }
 
 export default window.requirejs(findConfigName(window.requirejs.entries)).default;

--- a/tests/unit/find-test.js
+++ b/tests/unit/find-test.js
@@ -1,0 +1,21 @@
+import { Array_find as find } from 'ember-get-config/find';
+import { module, test } from 'qunit';
+
+module('ember-get-config');
+
+let count = 0;
+const array = ['foo', 'bar', 'biz'];
+const value = find.call(array, (entry) => ++count && /.a./.test(entry));
+
+test('it returns the matching value', function(assert) {
+  assert.equal(value, 'bar', 'it found the value');
+});
+
+test('it breaks early after finding a match', function(assert) {
+  assert.equal(count, 2, 'it did not test any more entries after finding the first match');
+});
+
+test('it returns undefined if no matching value is found', function(assert) {
+  const ret = find.call(array, () => false);
+  assert.equal(ret, undefined, 'returned undefined');
+});


### PR DESCRIPTION
Skip over any remaining module names after finding the config file's module name by swapping `find` for `filter`. `find` doesn't exist in all browsers yet, so this adds a simple, local polyfill for it.