### PR TITLE
Increase specificity of module name regex

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,7 @@
-const configName = Object.keys(window.requirejs.entries).filter((entry) => {
-  return entry.match(/\/config\/environment/);
-})[0];
+export function findConfigName(entries) {
+  return Object.keys(entries).filter((entry) => {
+    return entry.match(/^[^/]+\/config\/environment$/);
+  })[0];
+}
 
-export default window.requirejs(configName).default;
+export default window.requirejs(findConfigName(window.requirejs.entries)).default;

--- a/tests/dummy/app/helpers/config/environment.js
+++ b/tests/dummy/app/helpers/config/environment.js
@@ -1,0 +1,1 @@
+// A "helper" for testing app config name resolution.

--- a/tests/unit/ember-get-config-test.js
+++ b/tests/unit/ember-get-config-test.js
@@ -1,8 +1,37 @@
-import config from 'ember-get-config';
+import config, { findConfigName } from 'ember-get-config';
 import { module, test } from 'qunit';
 
 module('ember get config');
 
-test('it returns the app config file', function(assert) {
+test('it exports the app config file', function(assert) {
   assert.equal(config.environment, 'test');
+});
+
+test('it finds the module name', function(assert) {
+  function randomString(chars='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-',
+                        length=Math.floor(Math.random() * (33 - 5) + 5)) {
+    var result = '';
+    for (var i = length; i > 0; --i) {
+      result += chars[Math.floor(Math.random() * chars.length)];
+    }
+    return result;
+  }
+
+  const appName = randomString();
+  const alphaWithSlash = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-/';
+
+  const withConfigModule = {
+    [`${appName}/${randomString(alphaWithSlash)}/config/environment`]: false,
+    [`${appName}/config/environment/${randomString(alphaWithSlash)}`]: false,
+    [`${appName}/config/environment`]: true,
+  };
+
+  assert.equal(findConfigName(withConfigModule), `${appName}/config/environment`, `module name is found`);
+
+  const noConfigModule = {
+    [`${appName}/${randomString(alphaWithSlash)}/config/environment`]: false,
+    [`${appName}/config/environment/${randomString(alphaWithSlash)}`]: false,
+  };
+
+  assert.equal(findConfigName(noConfigModule), undefined, `module name is not found (b/c it doesn't exist`);
 });


### PR DESCRIPTION
Increase the specificity of the regular expression that matches the config file's module name. This prevents it from mistakenly matching other module names that happen to contain "/config/environment".