### PR TITLE
Don't mutate our own source code

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,1 +1,0 @@
-export { default } from 'dummy/config/environment';

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var fs = require('fs');
 var path = require('path');
 var count = 0;
+var FileCreator = require('broccoli-file-creator');
 
 function findRoot(current) {
   var app;
@@ -22,14 +23,12 @@ module.exports = {
 
   treeForAddon: function() {
     var modulePrefix = findRoot(this).project.config(process.env.EMBER_ENV)['modulePrefix'];
-
-    fs.writeFileSync(
-      path.join(__dirname, 'addon/index.js'),
-      'export { default } from \'' + modulePrefix + '/config/environment\';',
-      'utf-8'
+    var indexTree = new FileCreator(
+      'index.js',
+      'export { default } from \'' + modulePrefix + '/config/environment\';'
     );
 
-    return this._super.treeForAddon.apply(this, arguments);
+    return this._super.treeForAddon.call(this, indexTree);
   },
 
   included: function() {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "broccoli-file-creator": "^1.1.1",
     "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {


### PR DESCRIPTION
We have an in-repo addon that uses ember-get-config, and it's shared by multiple applications that we often build in parallel with one another. This means that between when this addon emits a new `addon/index.js` for a particular app and when that file actually gets consumed by that app's build, it can get overwritten by the `addon/index.js` for a different app, resulting in a broken import in the final build.

This change switches over to emitting the generated `index.js` directly into ember-get-config's broccoli tree, rather than mutating the source in place.