### PR TITLE
Remove `included` deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,14 +28,5 @@ module.exports = {
     );
 
     return this._super.treeForAddon.call(this, indexTree);
-  },
-
-  _includedCount: 0,
-
-  included: function() {
-    this._includedCount++;
-    if (this._includedCount > 1) {
-      findRoot(this).project.ui.writeDeprecateLine('`ember-get-config` previously recommended reinvoking the `included` hook, but that is no longer recommended. Please remove the additional invocation.');
-    }
   }
 };


### PR DESCRIPTION
I'd like to propose removing the double `included` warning from this addon. A fair amount of time has passed since it was added, and ember-get-config has moved from 0.1.x to 0.2.x since then, which, [by the way `node-semver` reckons things](https://github.com/npm/node-semver#caret-ranges-123-025-004), crosses a "breaking change" line and opens the door for things like removing support for/warnings around deprecated behavior. 

There's currently [an issue in ember-engines](https://github.com/ember-engines/ember-engines/issues/405) (which may or may not be a bug, given that addon's complex build pipeline patches) that's triggering the warning, and it would be great to be able to avoid that.